### PR TITLE
Remove Try/Catch in res.on("end");

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,7 @@ var query = function(path, done) {
         });
 
         res.on('end', function() {
-            try {
-                done(false, output, path);
-            } catch(e) {
-                done(e, output, path);
-            }
+            done(false, output, path);
         });
     }).on('error', function(e) {
         done(e, null, path, null);


### PR DESCRIPTION
The Try/Catch triggers the done(); callback twice, if an exception occurs somewhere in the asigned callback function. 

For example:

```javascript 
nominatim.reverse({
    "lat": payload.coordinates.latitude,
    "lon": payload.coordinates.longitude
}, function (err, geocoded) {
    // ...
    throw "error";

    // the next time this is called, err will be "error" and geocoded = undefined 😔
});
```

This will trigger the callback twice, which is especially difficult if you rely on it being triggered only once, for example when using the nominatim client within [async](https://github.com/caolan/async).

The error handling of the downstream-callback should be handled within the downstream-callback and not in the nominatim client 😊